### PR TITLE
feat: add next business day and event filtering to og cal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "yasumi",
  "yup-oauth2",
 ]
 
@@ -2092,6 +2093,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yasumi"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "922bf65bd77d1aa32e2d4941a811a29b382d4a33d24b64f45b484ef25263804e"
+dependencies = [
+ "chrono",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ google-calendar3 = "5.0"
 dirs = "5.0"
 hyper = { version = "0.14", features = ["full"] }
 hyper-rustls = "0.25"
+yasumi = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,10 @@ enum Commands {
     Cal {
         #[arg(long = "title", help = "Show only titles without time")]
         title: bool,
+        #[arg(long = "next", short = 'n', help = "Show next business day events")]
+        next: bool,
+        #[arg(long = "all", short = 'a', help = "Show all events including all-day and hidden events")]
+        all: bool,
     },
 }
 
@@ -140,8 +144,14 @@ async fn main() -> Result<(), String> {
                     print!("{}", markdown_out);
                 }
             },
-            Commands::Cal { title } => {
-                match calendar::get_today_events(title).await {
+            Commands::Cal { title, next, all } => {
+                let events_result = if next {
+                    calendar::get_next_business_day_events(all).await
+                } else {
+                    calendar::get_today_events(all).await
+                };
+                
+                match events_result {
                     Ok(events) => {
                         let output = calendar::format_events_output(&events, title);
                         print!("{}", output);


### PR DESCRIPTION
- Add --next/-n option to show next business day events with Japanese holiday support
- Add --all/-a option to control visibility of all-day and hidden events
- Implement business day calculation using yasumi crate for Japanese holidays
- Add event filtering to hide all-day events and events starting with '.' by default
- Support combined flags like -na, -an for flexible usage

🤖 Generated with [Claude Code](https://claude.ai/code)